### PR TITLE
query from `de_bundestag_plpr` table, not from `data`

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -169,7 +169,7 @@ def parse_transcript(filename):
         seq += 1
         table.insert(contrib)
 
-    q = '''SELECT * FROM data WHERE wahlperiode = :w AND sitzung = :s
+    q = '''SELECT * FROM de_bundestag_plpr WHERE wahlperiode = :w AND sitzung = :s
             ORDER BY sequence ASC'''
     fcsv = os.path.basename(filename).replace('.txt', '.csv')
     rp = eng.query(q, w=wp, s=session)


### PR DESCRIPTION
The table in which the data is stored was renamed in commit 164bc987 from `data` to `de_bundestag_plpr`.
Therefore the query needs to be adapted as well.